### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/docker-image-argoworkflow
+++ b/.github/docker-image-argoworkflow
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Publish to Registry
       id: publish-image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{github.repository}}
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -50,7 +50,7 @@ jobs:
       # publish to registry with tag as sha and as another tag as latest
       # - name: Publish to Registry
       #   id: publish-image
-      #   uses: elgohr/Publish-Docker-Github-Action@master
+      #   uses: elgohr/Publish-Docker-Github-Action@v5
       #   with:
       #     name: ${{github.repository}}
       #     username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -62,7 +62,7 @@ jobs:
       # publish to registry with tag as sha, another tag received from github tag
       - name: Publish to Registry
         id: publish-image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{github.repository}}
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       # publish to registry with tag as sha, another tag received from github tag
       - name: Publish to Registry
         id: publish-image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{github.repository}}
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore